### PR TITLE
Added support for lists to serialize child element with tags based on their class name

### DIFF
--- a/dev/src/main/resources/name/pehl/piriti/rebind/xml/writer/property/collection.vm
+++ b/dev/src/main/resources/name/pehl/piriti/rebind/xml/writer/property/collection.vm
@@ -18,6 +18,10 @@ if ($value != null)
     {
         if (currentValue != null)
         {
+            #if (!$property.xpath)
+        		String nestedElementName = currentValue.getClass().getName();
+        		nestedPath = nestedElementName.substring(nestedElementName.lastIndexOf(".")+1).toLowerCase();
+        	#end
             #parse($property.templates.elementType)
         }
         else


### PR DESCRIPTION
Added a way for objects being in a List to be serialised with a tag name that use the object class name.  

For example, here below is a Car object that contains a List property named childrens. In this list are a Motor and Wheel objects. By setting path='',  the serialised doc will be:

<Car>
 <Motor/>
 <Wheel/>
</Car>

@Mappings({

```
@Mapping( value="childrens", path="" ),
```

})

public interface CarXmlWriter extends XmlWriter<Car> {

}
