### PR TITLE
Fixed a bug that happens in some cases with generics

### DIFF
--- a/dev/src/main/java/name/pehl/piriti/rebind/type/TypeUtils.java
+++ b/dev/src/main/java/name/pehl/piriti/rebind/type/TypeUtils.java
@@ -527,7 +527,7 @@ public final class TypeUtils
 
         JClassType implType = null;
         for (JClassType t : typeOracle.getTypes()) {
-            if (t.isAssignableTo(parameterizedType) && t != type) {
+            if (t != type && t.isAssignableTo(parameterizedType)) {
                 implType = t;
                 break;
             }

--- a/dev/src/main/java/name/pehl/piriti/rebind/type/TypeUtils.java
+++ b/dev/src/main/java/name/pehl/piriti/rebind/type/TypeUtils.java
@@ -527,7 +527,7 @@ public final class TypeUtils
 
         JClassType implType = null;
         for (JClassType t : typeOracle.getTypes()) {
-            if (t.isAssignableTo(parameterizedType)) {
+            if (t.isAssignableTo(parameterizedType) && t != type) {
                 implType = t;
                 break;
             }

--- a/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
@@ -5,6 +5,7 @@ import java.util.List;
 public class GetResults<T>
 {
     List<T> results;
+    SomeGeneric<T> generic;
 
     GetResults()
     {
@@ -13,6 +14,7 @@ public class GetResults<T>
     public GetResults(List<T> results)
     {
         this.results = results;
+        this.generic = new SomeGeneric<T>(results.get(0));
     }
 
     public List<T> getResults()

--- a/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
@@ -1,24 +1,43 @@
 package name.pehl.piriti.client.generics;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public class GetResults<T>
-{
+public class GetResults<T> {
     List<T> results;
     SomeGeneric<T> generic;
+    List<String> someList;
 
-    GetResults()
-    {
+    GetResults() {
     }
 
-    public GetResults(List<T> results)
-    {
+    public GetResults(List<T> results) {
         this.results = results;
         this.generic = new SomeGeneric<T>(results.get(0));
+        someList = new ArrayList<String>();
     }
 
-    public List<T> getResults()
-    {
+    public List<T> getResults() {
         return results;
+    }
+
+    public List<String> getSomeList() {
+        return someList;
+    }
+
+    public SomeGeneric<T> getGeneric() {
+        return generic;
+    }
+
+    public void setResults(List<T> results) {
+        this.results = results;
+    }
+
+    public void setGeneric(SomeGeneric<T> generic) {
+        this.generic = generic;
+    }
+
+    public void setSomeList(List<String> someList) {
+        this.someList = someList;
     }
 }

--- a/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
@@ -9,36 +9,44 @@ public class GetResults<T>
     SomeGeneric<T> generic;
     List<String> someList;
 
-    GetResults() {
+    GetResults()
+    {
     }
 
-    public GetResults(List<T> results) {
+    public GetResults(List<T> results)
+    {
         this.results = results;
         this.generic = new SomeGeneric<T>(results.get(0));
         someList = new ArrayList<String>();
     }
 
-    public List<T> getResults() {
+    public List<T> getResults()
+    {
         return results;
     }
 
-    public List<String> getSomeList() {
+    public List<String> getSomeList()
+    {
         return someList;
     }
 
-    public SomeGeneric<T> getGeneric() {
+    public SomeGeneric<T> getGeneric()
+    {
         return generic;
     }
 
-    public void setResults(List<T> results) {
+    public void setResults(List<T> results)
+    {
         this.results = results;
     }
 
-    public void setGeneric(SomeGeneric<T> generic) {
+    public void setGeneric(SomeGeneric<T> generic)
+    {
         this.generic = generic;
     }
 
-    public void setSomeList(List<String> someList) {
+    public void setSomeList(List<String> someList)
+    {
         this.someList = someList;
     }
 }

--- a/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/GetResults.java
@@ -3,7 +3,8 @@ package name.pehl.piriti.client.generics;
 import java.util.ArrayList;
 import java.util.List;
 
-public class GetResults<T> {
+public class GetResults<T>
+{
     List<T> results;
     SomeGeneric<T> generic;
     List<String> someList;

--- a/dev/src/test/java/name/pehl/piriti/client/generics/JsonGenericsTest.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/JsonGenericsTest.java
@@ -22,6 +22,14 @@ public class JsonGenericsTest extends AbstractPiritiTest
     {
     }
 
+    interface IntegerNumberWrapperSGJsonReaderWriter extends JsonReaderWriter<SomeGeneric<NumberWrapper<Integer>>>
+    {
+    }
+
+    interface IntegerSGJsonReaderWriter extends JsonReaderWriter<SomeGeneric<Integer>>
+    {
+    }
+
     private IntegerNumberWrapperJsonReaderWriter INT_NUM_JSON_READER_WRITER;
     private GetResultsIntNumberWrapperJsonReaderWriter GET_RESULTS_INT_NUMBER_WRAPPER_JSON_READER_WRITER;
     private GetResultsIntegerJsonReaderWriter GET_RESULTS_INTEGER_READER_WRITER;
@@ -31,6 +39,8 @@ public class JsonGenericsTest extends AbstractPiritiTest
     {
         super.gwtSetUp();
 
+        GWT.create(IntegerSGJsonReaderWriter.class);
+        GWT.create(IntegerNumberWrapperSGJsonReaderWriter.class);
         INT_NUM_JSON_READER_WRITER = GWT.create(IntegerNumberWrapperJsonReaderWriter.class);
         GET_RESULTS_INT_NUMBER_WRAPPER_JSON_READER_WRITER =
                 GWT.create(GetResultsIntNumberWrapperJsonReaderWriter.class);

--- a/dev/src/test/java/name/pehl/piriti/client/generics/JsonGenericsTest.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/JsonGenericsTest.java
@@ -22,15 +22,14 @@ public class JsonGenericsTest extends AbstractPiritiTest
     {
     }
 
-    interface IntegerNumberWrapperSGJsonReaderWriter extends JsonReaderWriter<SomeGeneric<NumberWrapper<Integer>>>
+    interface IntegerNumberWrapperSomeGenericJsonReaderWriter extends JsonReaderWriter<SomeGeneric<NumberWrapper<Integer>>>
     {
     }
 
-    interface IntegerSGJsonReaderWriter extends JsonReaderWriter<SomeGeneric<Integer>>
+    interface IntegerSomeGenericJsonReaderWriter extends JsonReaderWriter<SomeGeneric<Integer>>
     {
     }
 
-    private IntegerNumberWrapperJsonReaderWriter INT_NUM_JSON_READER_WRITER;
     private GetResultsIntNumberWrapperJsonReaderWriter GET_RESULTS_INT_NUMBER_WRAPPER_JSON_READER_WRITER;
     private GetResultsIntegerJsonReaderWriter GET_RESULTS_INTEGER_READER_WRITER;
 
@@ -39,9 +38,8 @@ public class JsonGenericsTest extends AbstractPiritiTest
     {
         super.gwtSetUp();
 
-        GWT.create(IntegerSGJsonReaderWriter.class);
-        GWT.create(IntegerNumberWrapperSGJsonReaderWriter.class);
-        INT_NUM_JSON_READER_WRITER = GWT.create(IntegerNumberWrapperJsonReaderWriter.class);
+        GWT.create(IntegerSomeGenericJsonReaderWriter.class);
+        GWT.create(IntegerNumberWrapperSomeGenericJsonReaderWriter.class);
         GET_RESULTS_INT_NUMBER_WRAPPER_JSON_READER_WRITER =
                 GWT.create(GetResultsIntNumberWrapperJsonReaderWriter.class);
         GET_RESULTS_INTEGER_READER_WRITER = GWT.create(GetResultsIntegerJsonReaderWriter.class);

--- a/dev/src/test/java/name/pehl/piriti/client/generics/JsonGenericsTest.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/JsonGenericsTest.java
@@ -40,6 +40,7 @@ public class JsonGenericsTest extends AbstractPiritiTest
 
         GWT.create(IntegerSomeGenericJsonReaderWriter.class);
         GWT.create(IntegerNumberWrapperSomeGenericJsonReaderWriter.class);
+        GWT.create(IntegerNumberWrapperJsonReaderWriter.class);
         GET_RESULTS_INT_NUMBER_WRAPPER_JSON_READER_WRITER =
                 GWT.create(GetResultsIntNumberWrapperJsonReaderWriter.class);
         GET_RESULTS_INTEGER_READER_WRITER = GWT.create(GetResultsIntegerJsonReaderWriter.class);

--- a/dev/src/test/java/name/pehl/piriti/client/generics/SomeGeneric.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/SomeGeneric.java
@@ -1,0 +1,19 @@
+package name.pehl.piriti.client.generics;
+
+public class SomeGeneric<T> {
+    private T value;
+
+    SomeGeneric(){}
+
+    public SomeGeneric(T value) {
+        this.value = value;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+}

--- a/dev/src/test/java/name/pehl/piriti/client/generics/SomeGeneric.java
+++ b/dev/src/test/java/name/pehl/piriti/client/generics/SomeGeneric.java
@@ -1,19 +1,25 @@
 package name.pehl.piriti.client.generics;
 
-public class SomeGeneric<T> {
+public class SomeGeneric<T>
+{
     private T value;
 
-    SomeGeneric(){}
+    SomeGeneric()
+    {
+    }
 
-    public SomeGeneric(T value) {
+    public SomeGeneric(T value)
+    {
         this.value = value;
     }
 
-    public T getValue() {
+    public T getValue()
+    {
         return value;
     }
 
-    public void setValue(T value) {
+    public void setValue(T value)
+    {
         this.value = value;
     }
 }

--- a/playground/pom.xml
+++ b/playground/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>name.pehl</groupId>
         <artifactId>piriti-parent</artifactId>
-        <version>0.9-SNAPSHOT</version>
+        <version>0.11-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>piriti-playground</artifactId>


### PR DESCRIPTION
Prevent the error :
You must use a subtype of JsonReader? in GWT.create(). E.g., java? interface ModelReader? extends JsonReader?<Model> {} java? ModelReader? reader = GWT.create(ModelReader?.class); java
