### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/user/src/main/java/name/pehl/piriti/commons/client/ModelReadEvent.java
+++ b/user/src/main/java/name/pehl/piriti/commons/client/ModelReadEvent.java
@@ -18,6 +18,23 @@ public class ModelReadEvent<T, C> extends GwtEvent<ModelReadHandler<T, C>>
      * Handler type.
      */
     private static Type<ModelReadHandler<?, ?>> TYPE;
+    private final T model;
+    private final C context;
+
+
+    /**
+     * Creates a new event.
+     *
+     * @param model
+     *            the model
+     * @param context
+     *            the context i.e the JSONObject or XML element
+     */
+    protected ModelReadEvent(T model, C context)
+    {
+        this.model = model;
+        this.context = context;
+    }
 
 
     /**
@@ -55,24 +72,6 @@ public class ModelReadEvent<T, C> extends GwtEvent<ModelReadHandler<T, C>>
             TYPE = new Type<ModelReadHandler<?, ?>>();
         }
         return TYPE;
-    }
-
-    private final T model;
-    private final C context;
-
-
-    /**
-     * Creates a new event.
-     * 
-     * @param model
-     *            the model
-     * @param context
-     *            the context i.e the JSONObject or XML element
-     */
-    protected ModelReadEvent(T model, C context)
-    {
-        this.model = model;
-        this.context = context;
     }
 
 

--- a/user/src/main/java/name/pehl/piriti/commons/client/ModelWriteEvent.java
+++ b/user/src/main/java/name/pehl/piriti/commons/client/ModelWriteEvent.java
@@ -16,6 +16,23 @@ public class ModelWriteEvent<T> extends GwtEvent<ModelWriteHandler<T>>
      * Handler type.
      */
     private static Type<ModelWriteHandler<?>> TYPE;
+    private final T model;
+    private final String representation;
+
+
+    /**
+     * Creates a new event.
+     *
+     * @param model
+     *            the model
+     * @param representation
+     *            the string representation of the model
+     */
+    protected ModelWriteEvent(T model, String representation)
+    {
+        this.model = model;
+        this.representation = representation;
+    }
 
 
     /**
@@ -55,23 +72,6 @@ public class ModelWriteEvent<T> extends GwtEvent<ModelWriteHandler<T>>
         return TYPE;
     }
 
-    private final T model;
-    private final String representation;
-
-
-    /**
-     * Creates a new event.
-     * 
-     * @param model
-     *            the model
-     * @param representation
-     *            the string representation of the model
-     */
-    protected ModelWriteEvent(T model, String representation)
-    {
-        this.model = model;
-        this.representation = representation;
-    }
 
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
