### PR TITLE
Multiple code improvements - squid:CommentedOutCodeLine, squid:SwitchLastCaseIsDefaultCheck, squid:S00115, squid:S00100

### DIFF
--- a/dev/src/main/java/name/pehl/piriti/rebind/property/PropertyTemplatesLookup.java
+++ b/dev/src/main/java/name/pehl/piriti/rebind/property/PropertyTemplatesLookup.java
@@ -141,6 +141,8 @@ public class PropertyTemplatesLookup
                     template = "any.vm";
                 }
                 break;
+            default:
+                break;
         }
         return template;
     }

--- a/dev/src/main/java/name/pehl/piriti/rebind/type/RwTypeProcessor.java
+++ b/dev/src/main/java/name/pehl/piriti/rebind/type/RwTypeProcessor.java
@@ -137,7 +137,7 @@ public class RwTypeProcessor extends AbstractTypeProcessor
         @Override
         public boolean isNative()
         {
-            return mapping.native_();
+            return mapping.isNative();
         }
 
 

--- a/user/src/main/java/name/pehl/piriti/commons/client/Mapping.java
+++ b/user/src/main/java/name/pehl/piriti/commons/client/Mapping.java
@@ -105,5 +105,5 @@ public @interface Mapping
      * 
      * @return
      */
-    boolean native_() default false;
+    boolean isNative() default false;
 }

--- a/user/src/main/java/name/pehl/piriti/converter/client/MsDateTimeFormat.java
+++ b/user/src/main/java/name/pehl/piriti/converter/client/MsDateTimeFormat.java
@@ -28,8 +28,8 @@ public class MsDateTimeFormat extends DateTimeFormat
     public static final String PATTERN = "MsDateTimeFormat()";
 
     // Pre and post string where formatting dates, pretty simple
-    public static final String prefix = "/Date(";
-    public static final String postfix = ")/";
+    public static final String PREFIX = "/Date(";
+    public static final String POSTFIX = ")/";
 
     // Private JS object to store regexok
     private static JavaScriptObject regexp;
@@ -45,7 +45,7 @@ public class MsDateTimeFormat extends DateTimeFormat
     @Override
     public String format(Date date)
     {
-        return prefix + date.getTime() + postfix;
+        return PREFIX + date.getTime() + POSTFIX;
     }
 
 
@@ -67,7 +67,7 @@ public class MsDateTimeFormat extends DateTimeFormat
     public Date parse(String text) throws IllegalArgumentException
     {
         // Test if match expressiom, convert !
-        return matches(text) ? new Date(Long.parseLong(text.substring(prefix.length(), text.lastIndexOf(')')))) : null;
+        return matches(text) ? new Date(Long.parseLong(text.substring(PREFIX.length(), text.lastIndexOf(')')))) : null;
     }
 
 

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/javax/xml/bind/annotation/XmlSchema.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/javax/xml/bind/annotation/XmlSchema.java
@@ -97,7 +97,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  *    // Package level annotation
  *    &#64;javax.xml.bind.annotation.XmlSchema (
  *      xmlns = { 
- *        &#64;javax.xml.bind.annotation.XmlNs(prefix = "po", 
+ *        &#64;javax.xml.bind.annotation.XmlNs(prefix = "po",
  *                   namespaceURI="http://www.example.com/myPO1"),
  *
  *        &#64;javax.xml.bind.annotation.XmlNs(prefix="xs",

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/DOMConfiguration.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/DOMConfiguration.java
@@ -190,7 +190,7 @@ package org.w3c.dom;
  * .</dd>
  * <dt><code>false</code></dt>
  * <dd>[<em>required</em>]Discard all namespace declaration attributes. The namespace prefixes (
- * <code>Node.prefix</code>) are retained even if this parameter is set to 
+ * <code>Node.prefix</code>) are retained even if this parameter is set to
  * <code>false</code>.</dd>
  * </dl></dd>
  * <dt><code>"normalize-characters"</code></dt>

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/DOMImplementation.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/DOMImplementation.java
@@ -84,11 +84,11 @@ public interface DOMImplementation {
      *   INVALID_CHARACTER_ERR: Raised if the specified qualified name is not 
      *   an XML name according to [<a href='http://www.w3.org/TR/2004/REC-xml-20040204'>XML 1.0</a>].
      *   <br>NAMESPACE_ERR: Raised if the <code>qualifiedName</code> is 
-     *   malformed, if the <code>qualifiedName</code> has a prefix and the 
+     *   malformed, if the <code>qualifiedName</code> has a prefix and the
      *   <code>namespaceURI</code> is <code>null</code>, or if the 
      *   <code>qualifiedName</code> is <code>null</code> and the 
      *   <code>namespaceURI</code> is different from <code>null</code>, or 
-     *   if the <code>qualifiedName</code> has a prefix that is "xml" and 
+     *   if the <code>qualifiedName</code> has a prefix that is "xml" and
      *   the <code>namespaceURI</code> is different from "<a href='http://www.w3.org/XML/1998/namespace'>
      *   http://www.w3.org/XML/1998/namespace</a>" [<a href='http://www.w3.org/TR/1999/REC-xml-names-19990114/'>XML Namespaces</a>]
      *   , or if the DOM implementation does not support the 

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/Document.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/Document.java
@@ -76,7 +76,7 @@ public interface Document extends Node {
      *   implementation.
      * @return A new <code>Element</code> object with the 
      *   <code>nodeName</code> attribute set to <code>tagName</code>, and 
-     *   <code>localName</code>, <code>prefix</code>, and 
+     *   <code>localName</code>, <code>prefix</code>, and
      *   <code>namespaceURI</code> set to <code>null</code>.
      * @exception DOMException
      *   INVALID_CHARACTER_ERR: Raised if the specified name is not an XML 
@@ -148,7 +148,7 @@ public interface Document extends Node {
      * @param name The name of the attribute.
      * @return A new <code>Attr</code> object with the <code>nodeName</code> 
      *   attribute set to <code>name</code>, and <code>localName</code>, 
-     *   <code>prefix</code>, and <code>namespaceURI</code> set to 
+     *   <code>prefix</code>, and <code>namespaceURI</code> set to
      *   <code>null</code>. The value of the attribute is the empty string.
      * @exception DOMException
      *   INVALID_CHARACTER_ERR: Raised if the specified name is not an XML 
@@ -164,7 +164,7 @@ public interface Document extends Node {
      * <code>EntityReference</code> node is made the same as that of the 
      * corresponding <code>Entity</code> node.
      * <p ><b>Note:</b> If any descendant of the <code>Entity</code> node has 
-     * an unbound namespace prefix, the corresponding descendant of the 
+     * an unbound namespace prefix, the corresponding descendant of the
      * created <code>EntityReference</code> node is also unbound; (its 
      * <code>namespaceURI</code> is <code>null</code>). The DOM Level 2 and 
      * 3 do not support any mechanism to resolve namespace prefixes in this 
@@ -207,7 +207,7 @@ public interface Document extends Node {
      * <br>For all nodes, importing a node creates a node object owned by the 
      * importing document, with attribute values identical to the source 
      * node's <code>nodeName</code> and <code>nodeType</code>, plus the 
-     * attributes related to namespaces (<code>prefix</code>, 
+     * attributes related to namespaces (<code>prefix</code>,
      * <code>localName</code>, and <code>namespaceURI</code>). As in the 
      * <code>cloneNode</code> operation, the source node is not altered. 
      * User data associated to the imported node is not carried over. 
@@ -341,7 +341,7 @@ public interface Document extends Node {
      * </tr>
      * <tr>
      * <td valign='top' rowspan='1' colspan='1'><code>Node.prefix</code></td>
-     * <td valign='top' rowspan='1' colspan='1'>prefix, extracted 
+     * <td valign='top' rowspan='1' colspan='1'>prefix, extracted
      *   from <code>qualifiedName</code>, or <code>null</code> if there is 
      *   no prefix</td>
      * </tr>
@@ -363,11 +363,11 @@ public interface Document extends Node {
      *   attribute.
      *   <br>NAMESPACE_ERR: Raised if the <code>qualifiedName</code> is a 
      *   malformed qualified name, if the <code>qualifiedName</code> has a 
-     *   prefix and the <code>namespaceURI</code> is <code>null</code>, or 
-     *   if the <code>qualifiedName</code> has a prefix that is "xml" and 
+     *   prefix and the <code>namespaceURI</code> is <code>null</code>, or
+     *   if the <code>qualifiedName</code> has a prefix that is "xml" and
      *   the <code>namespaceURI</code> is different from "<a href='http://www.w3.org/XML/1998/namespace'>
      *   http://www.w3.org/XML/1998/namespace</a>" [<a href='http://www.w3.org/TR/1999/REC-xml-names-19990114/'>XML Namespaces</a>]
-     *   , or if the <code>qualifiedName</code> or its prefix is "xmlns" and 
+     *   , or if the <code>qualifiedName</code> or its prefix is "xmlns" and
      *   the <code>namespaceURI</code> is different from "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>", or if the <code>namespaceURI</code> is "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>" and neither the <code>qualifiedName</code> nor its prefix is "xmlns".
      *   <br>NOT_SUPPORTED_ERR: Always thrown if the current document does not 
      *   support the <code>"XML"</code> feature, since namespaces were 
@@ -406,7 +406,7 @@ public interface Document extends Node {
      * <tr>
      * <td valign='top' rowspan='1' colspan='1'>
      *   <code>Node.prefix</code></td>
-     * <td valign='top' rowspan='1' colspan='1'>prefix, extracted from 
+     * <td valign='top' rowspan='1' colspan='1'>prefix, extracted from
      *   <code>qualifiedName</code>, or <code>null</code> if there is no 
      *   prefix</td>
      * </tr>
@@ -433,10 +433,10 @@ public interface Document extends Node {
      *   attribute.
      *   <br>NAMESPACE_ERR: Raised if the <code>qualifiedName</code> is a 
      *   malformed qualified name, if the <code>qualifiedName</code> has a 
-     *   prefix and the <code>namespaceURI</code> is <code>null</code>, if 
-     *   the <code>qualifiedName</code> has a prefix that is "xml" and the 
+     *   prefix and the <code>namespaceURI</code> is <code>null</code>, if
+     *   the <code>qualifiedName</code> has a prefix that is "xml" and the
      *   <code>namespaceURI</code> is different from "<a href='http://www.w3.org/XML/1998/namespace'>
-     *   http://www.w3.org/XML/1998/namespace</a>", if the <code>qualifiedName</code> or its prefix is "xmlns" and the 
+     *   http://www.w3.org/XML/1998/namespace</a>", if the <code>qualifiedName</code> or its prefix is "xmlns" and the
      *   <code>namespaceURI</code> is different from "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>", or if the <code>namespaceURI</code> is "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>" and neither the <code>qualifiedName</code> nor its prefix is "xmlns".
      *   <br>NOT_SUPPORTED_ERR: Always thrown if the current document does not 
      *   support the <code>"XML"</code> feature, since namespaces were 
@@ -798,12 +798,12 @@ public interface Document extends Node {
      *   from a different document than this document.
      *   <br>NAMESPACE_ERR: Raised if the <code>qualifiedName</code> is a 
      *   malformed qualified name, if the <code>qualifiedName</code> has a 
-     *   prefix and the <code>namespaceURI</code> is <code>null</code>, or 
-     *   if the <code>qualifiedName</code> has a prefix that is "xml" and 
+     *   prefix and the <code>namespaceURI</code> is <code>null</code>, or
+     *   if the <code>qualifiedName</code> has a prefix that is "xml" and
      *   the <code>namespaceURI</code> is different from "<a href='http://www.w3.org/XML/1998/namespace'>
      *   http://www.w3.org/XML/1998/namespace</a>" [<a href='http://www.w3.org/TR/1999/REC-xml-names-19990114/'>XML Namespaces</a>]
      *   . Also raised, when the node being renamed is an attribute, if the 
-     *   <code>qualifiedName</code>, or its prefix, is "xmlns" and the 
+     *   <code>qualifiedName</code>, or its prefix, is "xmlns" and the
      *   <code>namespaceURI</code> is different from "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>".
      * @since DOM Level 3
      */

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/Element.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/Element.java
@@ -82,7 +82,7 @@ public interface Element extends Node {
      * Removes an attribute by name. If a default value for the removed 
      * attribute is defined in the DTD, a new attribute immediately appears 
      * with the default value as well as the corresponding namespace URI, 
-     * local name, and prefix when applicable. The implementation may handle 
+     * local name, and prefix when applicable. The implementation may handle
      * default values from other schemas similarly but applications should 
      * use <code>Document.normalizeDocument()</code> to guarantee this 
      * information is up-to-date.
@@ -135,7 +135,7 @@ public interface Element extends Node {
      * Removes the specified attribute node. If a default value for the 
      * removed <code>Attr</code> node is defined in the DTD, a new node 
      * immediately appears with the default value as well as the 
-     * corresponding namespace URI, local name, and prefix when applicable. 
+     * corresponding namespace URI, local name, and prefix when applicable.
      * The implementation may handle default values from other schemas 
      * similarly but applications should use 
      * <code>Document.normalizeDocument()</code> to guarantee this 
@@ -182,8 +182,8 @@ public interface Element extends Node {
 
     /**
      * Adds a new attribute. If an attribute with the same local name and 
-     * namespace URI is already present on the element, its prefix is 
-     * changed to be the prefix part of the <code>qualifiedName</code>, and 
+     * namespace URI is already present on the element, its prefix is
+     * changed to be the prefix part of the <code>qualifiedName</code>, and
      * its value is changed to be the <code>value</code> parameter. This 
      * value is a simple string; it is not parsed as it is being set. So any 
      * markup (such as syntax to be recognized as an entity reference) is 
@@ -211,11 +211,11 @@ public interface Element extends Node {
      *   <br>NO_MODIFICATION_ALLOWED_ERR: Raised if this node is readonly.
      *   <br>NAMESPACE_ERR: Raised if the <code>qualifiedName</code> is 
      *   malformed per the Namespaces in XML specification, if the 
-     *   <code>qualifiedName</code> has a prefix and the 
+     *   <code>qualifiedName</code> has a prefix and the
      *   <code>namespaceURI</code> is <code>null</code>, if the 
-     *   <code>qualifiedName</code> has a prefix that is "xml" and the 
+     *   <code>qualifiedName</code> has a prefix that is "xml" and the
      *   <code>namespaceURI</code> is different from "<a href='http://www.w3.org/XML/1998/namespace'>
-     *   http://www.w3.org/XML/1998/namespace</a>", if the <code>qualifiedName</code> or its prefix is "xmlns" and the 
+     *   http://www.w3.org/XML/1998/namespace</a>", if the <code>qualifiedName</code> or its prefix is "xmlns" and the
      *   <code>namespaceURI</code> is different from "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>", or if the <code>namespaceURI</code> is "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>" and neither the <code>qualifiedName</code> nor its prefix is "xmlns".
      *   <br>NOT_SUPPORTED_ERR: May be raised if the implementation does not 
      *   support the feature <code>"XML"</code> and the language exposed 
@@ -231,7 +231,7 @@ public interface Element extends Node {
      * Removes an attribute by local name and namespace URI. If a default 
      * value for the removed attribute is defined in the DTD, a new 
      * attribute immediately appears with the default value as well as the 
-     * corresponding namespace URI, local name, and prefix when applicable. 
+     * corresponding namespace URI, local name, and prefix when applicable.
      * The implementation may handle default values from other schemas 
      * similarly but applications should use 
      * <code>Document.normalizeDocument()</code> to guarantee this 

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/EntityReference.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/EntityReference.java
@@ -25,7 +25,7 @@ package org.w3c.dom;
  * entity an <code>Entity</code> exists, and the subtree of the 
  * <code>EntityReference</code> node is a copy of the <code>Entity</code> 
  * node subtree. However, the latter may not be true when an entity contains 
- * an unbound namespace prefix. In such a case, because the namespace prefix 
+ * an unbound namespace prefix. In such a case, because the namespace prefix
  * resolution depends on where the entity reference is, the descendants of 
  * the <code>EntityReference</code> node may be bound to different namespace 
  * URIs. When an <code>EntityReference</code> node represents a reference to 

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/Node.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/org/w3c/dom/Node.java
@@ -499,7 +499,7 @@ public interface Node {
     public String getNamespaceURI();
 
     /**
-     * The namespace prefix of this node, or <code>null</code> if it is 
+     * The namespace prefix of this node, or <code>null</code> if it is
      * unspecified. When it is defined to be <code>null</code>, setting it 
      * has no effect, including if the node is read-only.
      * <br>Note that setting this attribute, when permitted, changes the 
@@ -507,11 +507,11 @@ public interface Node {
      * well as the <code>tagName</code> and <code>name</code> attributes of 
      * the <code>Element</code> and <code>Attr</code> interfaces, when 
      * applicable.
-     * <br>Setting the prefix to <code>null</code> makes it unspecified, 
+     * <br>Setting the prefix to <code>null</code> makes it unspecified,
      * setting it to an empty string is implementation dependent.
-     * <br>Note also that changing the prefix of an attribute that is known to 
+     * <br>Note also that changing the prefix of an attribute that is known to
      * have a default value, does not make a new attribute with the default 
-     * value and the original prefix appear, since the 
+     * value and the original prefix appear, since the
      * <code>namespaceURI</code> and <code>localName</code> do not change.
      * <br>For nodes of any type other than <code>ELEMENT_NODE</code> and 
      * <code>ATTRIBUTE_NODE</code> and nodes created with a DOM Level 1 
@@ -522,7 +522,7 @@ public interface Node {
      */
     public String getPrefix();
     /**
-     * The namespace prefix of this node, or <code>null</code> if it is 
+     * The namespace prefix of this node, or <code>null</code> if it is
      * unspecified. When it is defined to be <code>null</code>, setting it 
      * has no effect, including if the node is read-only.
      * <br>Note that setting this attribute, when permitted, changes the 
@@ -530,27 +530,27 @@ public interface Node {
      * well as the <code>tagName</code> and <code>name</code> attributes of 
      * the <code>Element</code> and <code>Attr</code> interfaces, when 
      * applicable.
-     * <br>Setting the prefix to <code>null</code> makes it unspecified, 
+     * <br>Setting the prefix to <code>null</code> makes it unspecified,
      * setting it to an empty string is implementation dependent.
-     * <br>Note also that changing the prefix of an attribute that is known to 
+     * <br>Note also that changing the prefix of an attribute that is known to
      * have a default value, does not make a new attribute with the default 
-     * value and the original prefix appear, since the 
+     * value and the original prefix appear, since the
      * <code>namespaceURI</code> and <code>localName</code> do not change.
      * <br>For nodes of any type other than <code>ELEMENT_NODE</code> and 
      * <code>ATTRIBUTE_NODE</code> and nodes created with a DOM Level 1 
      * method, such as <code>createElement</code> from the 
      * <code>Document</code> interface, this is always <code>null</code>.
      * @exception DOMException
-     *   INVALID_CHARACTER_ERR: Raised if the specified prefix contains an 
+     *   INVALID_CHARACTER_ERR: Raised if the specified prefix contains an
      *   illegal character according to the XML version in use specified in 
      *   the <code>Document.xmlVersion</code> attribute.
      *   <br>NO_MODIFICATION_ALLOWED_ERR: Raised if this node is readonly.
-     *   <br>NAMESPACE_ERR: Raised if the specified <code>prefix</code> is 
+     *   <br>NAMESPACE_ERR: Raised if the specified <code>prefix</code> is
      *   malformed per the Namespaces in XML specification, if the 
      *   <code>namespaceURI</code> of this node is <code>null</code>, if the 
-     *   specified prefix is "xml" and the <code>namespaceURI</code> of this 
+     *   specified prefix is "xml" and the <code>namespaceURI</code> of this
      *   node is different from "<a href='http://www.w3.org/XML/1998/namespace'>
-     *   http://www.w3.org/XML/1998/namespace</a>", if this node is an attribute and the specified prefix is "xmlns" and 
+     *   http://www.w3.org/XML/1998/namespace</a>", if this node is an attribute and the specified prefix is "xmlns" and
      *   the <code>namespaceURI</code> of this node is different from "<a href='http://www.w3.org/2000/xmlns/'>http://www.w3.org/2000/xmlns/</a>", or if this node is an attribute and the <code>qualifiedName</code> of 
      *   this node is "xmlns" [<a href='http://www.w3.org/TR/1999/REC-xml-names-19990114/'>XML Namespaces</a>]
      *   .
@@ -759,14 +759,14 @@ public interface Node {
     public boolean isSameNode(Node other);
 
     /**
-     * Look up the prefix associated to the given namespace URI, starting from 
+     * Look up the prefix associated to the given namespace URI, starting from
      * this node. The default namespace declarations are ignored by this 
      * method.
      * <br>See  for details on the algorithm used by this method.
      * @param namespaceURI The namespace URI to look for.
-     * @return Returns an associated namespace prefix if found or 
-     *   <code>null</code> if none is found. If more than one prefix are 
-     *   associated to the namespace prefix, the returned namespace prefix 
+     * @return Returns an associated namespace prefix if found or
+     *   <code>null</code> if none is found. If more than one prefix are
+     *   associated to the namespace prefix, the returned namespace prefix
      *   is implementation dependent.
      *
      * @since DOM Level 3
@@ -786,10 +786,10 @@ public interface Node {
     public boolean isDefaultNamespace(String namespaceURI);
 
     /**
-     * Look up the namespace URI associated to the given prefix, starting from 
+     * Look up the namespace URI associated to the given prefix, starting from
      * this node.
      * <br>See  for details on the algorithm used by this method.
-     * @param prefix The prefix to look for. If this parameter is 
+     * @param prefix The prefix to look for. If this parameter is
      *   <code>null</code>, the method will return the default namespace URI 
      *   if any.
      * @return Returns the associated namespace URI or <code>null</code> if 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause.
squid:S00115 - Constant names should comply with a naming convention.
squid:S00100 - Method names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/rules/show/squid:S00115
https://dev.eclipse.org/sonar/rules/show/squid:S00100
Please let me know if you have any questions.
George Kankava
