### PR TITLE
remove unneeded awt imports which break GWT compilation.

### DIFF
--- a/user/src/main/resources/name/pehl/piriti/commons/jre/javax/xml/bind/annotation/XmlInlineBinaryData.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/javax/xml/bind/annotation/XmlInlineBinaryData.java
@@ -42,7 +42,6 @@ package javax.xml.bind.annotation;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.awt.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;

--- a/user/src/main/resources/name/pehl/piriti/commons/jre/javax/xml/bind/annotation/XmlMimeType.java
+++ b/user/src/main/resources/name/pehl/piriti/commons/jre/javax/xml/bind/annotation/XmlMimeType.java
@@ -42,7 +42,6 @@ package javax.xml.bind.annotation;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.awt.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;


### PR DESCRIPTION
I'm in process of reviving old GWT project, and I updating dependencies to latest. Still work in progress, can't say will it work with latest GWT, but at least these two unused imports break GWT build.

Cheers!
San.